### PR TITLE
added PrintCsv() function and unit tests to bluemix/terminal/table

### DIFF
--- a/bluemix/terminal/table.go
+++ b/bluemix/terminal/table.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"strings"
@@ -18,6 +19,7 @@ type Table interface {
 	Add(row ...string)
 	Print()
 	PrintJson()
+	PrintCsv()
 }
 
 type PrintableTable struct {
@@ -156,4 +158,10 @@ func (t *PrintableTable) PrintJson() {
 	fmt.Fprintln(t.writer, "]")
 	// mimic behavior of Print()
 	t.rows = [][]string{}
+}
+
+func (t *PrintableTable) PrintCsv() {
+	csvwriter := csv.NewWriter(t.writer)
+	csvwriter.Write(t.headers)
+	csvwriter.WriteAll(t.rows)
 }

--- a/bluemix/terminal/table_test.go
+++ b/bluemix/terminal/table_test.go
@@ -92,3 +92,36 @@ func TestNotEnoughRowEntiresJson(t *testing.T) {
 	assert.Contains(t, buf.String(), "\"column_1\": \"row1\"")
 	assert.Contains(t, buf.String(), "\"column_1\": \"\"")
 }
+
+func TestPrintCsvSimple(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"col1", "col2"})
+	testTable.Add("row1-col1", "row1-col2")
+	testTable.Add("row2-col1", "row2-col2")
+	testTable.PrintCsv()
+	assert.Contains(t, buf.String(), "col1,col2")
+	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
+	assert.Contains(t, buf.String(), "row2-col1,row2-col2")
+}
+
+func TestNotEnoughColPrintCsv(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"", "col2"})
+	testTable.Add("row1-col1", "row1-col2")
+	testTable.Add("row2-col1", "row2-col2")
+	testTable.PrintCsv()
+	assert.Contains(t, buf.String(), ",col2")
+	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
+	assert.Contains(t, buf.String(), "row2-col1,row2-col2")
+}
+
+func TestNotEnoughRowPrintCsv(t *testing.T) {
+	buf := bytes.Buffer{}
+	testTable := NewTable(&buf, []string{"col1", "col2"})
+	testTable.Add("row1-col1", "row1-col2")
+	testTable.Add("row2-col1", "")
+	testTable.PrintCsv()
+	assert.Contains(t, buf.String(), "col1,col2")
+	assert.Contains(t, buf.String(), "row1-col1,row1-col2")
+	assert.Contains(t, buf.String(), "row2-col1,")
+}


### PR DESCRIPTION
I would like to add a new format to represent the tables in `ibmcloud sl` where we use them a lot, print in csv format

Using the same format
```go
testTable := NewTable(&buf, []string{"col1", "col2"})
testTable.Add("row1-col1", "row1-col2")
testTable.Add("row2-col1", "row2-col2")
testTable.PrintCsv()
```
The output would look like this
```
col1,col2
row1-col1,row1-col2
row2-col1,row2-col2
```